### PR TITLE
[codex] Redact billing secrets from analytics

### DIFF
--- a/packages/rinawarp-agentd/src/analytics.ts
+++ b/packages/rinawarp-agentd/src/analytics.ts
@@ -100,6 +100,53 @@ let metricsFlushTimer: NodeJS.Timeout | null = null
 let posthog: any | null = null
 let posthogCtor: any | null = null
 
+const SENSITIVE_ANALYTICS_KEY_PATTERN = /(?:token|secret|password|api[_-]?key|license[_-]?key)/i
+const CUSTOMER_ID_ANALYTICS_KEY_PATTERN = /customer[_-]?id/i
+const REDACTED_ANALYTICS_VALUE = '[redacted]'
+
+function maskedIdentifier(value: unknown): string {
+  const raw = String(value || '').trim()
+  if (!raw) return REDACTED_ANALYTICS_VALUE
+  return `[redacted:${raw.slice(-4).padStart(Math.min(raw.length, 4), '*')}]`
+}
+
+function sanitizeAnalyticsValue(key: string, value: unknown, seen: WeakSet<object>): unknown {
+  if (CUSTOMER_ID_ANALYTICS_KEY_PATTERN.test(key)) {
+    return maskedIdentifier(value)
+  }
+
+  if (SENSITIVE_ANALYTICS_KEY_PATTERN.test(key)) {
+    return REDACTED_ANALYTICS_VALUE
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeAnalyticsValue(key, item, seen))
+  }
+
+  if (value && typeof value === 'object') {
+    if (seen.has(value)) return REDACTED_ANALYTICS_VALUE
+    seen.add(value)
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
+        childKey,
+        sanitizeAnalyticsValue(childKey, childValue, seen),
+      ])
+    )
+  }
+
+  return value
+}
+
+export function sanitizeAnalyticsProperties(
+  properties?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!properties) return undefined
+  const seen = new WeakSet<object>()
+  return Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => [key, sanitizeAnalyticsValue(key, value, seen)])
+  )
+}
+
 function loadPostHogCtor(): any | null {
   if (posthogCtor) return posthogCtor
   try {
@@ -178,6 +225,7 @@ export type ServerEvent =
   | 'invite_accepted'
   | 'subscription_created'
   | 'subscription_failed'
+  | 'api_license_generated'
   | 'api_request'
   | 'api_error'
   // Conversion funnel events
@@ -193,18 +241,19 @@ export type ServerEvent =
 export function trackServerEvent(event: ServerEvent, properties?: Record<string, unknown>): void {
   const ph = getPostHog()
   const eventId = randomUUID()
+  const sanitizedProperties = sanitizeAnalyticsProperties(properties)
 
   // Always update local metrics
-  updateLocalMetrics(event, properties)
+  updateLocalMetrics(event, sanitizedProperties)
 
   // Send to PostHog if available
   if (ph) {
     try {
       ph.capture({
-        distinctId: String(properties?.user_id || 'anonymous'),
+        distinctId: String(sanitizedProperties?.user_id || 'anonymous'),
         event: `agentd_${event}`,
         properties: {
-          ...properties,
+          ...sanitizedProperties,
           event_id: eventId,
           timestamp: new Date().toISOString(),
           service: 'agentd',

--- a/packages/rinawarp-agentd/src/server.ts
+++ b/packages/rinawarp-agentd/src/server.ts
@@ -1239,7 +1239,7 @@ export function createServer(opts: { port: number }) {
         }
 
         // Track in analytics
-        trackServerEvent('api_license_generated' as any, { tier, customer_id: customerId })
+        trackServerEvent('api_license_generated', { tier, customer_id: customerId })
 
         return sendJson(res, 200, { ok: true, license })
       }

--- a/packages/rinawarp-agentd/test/analytics-redaction.test.mjs
+++ b/packages/rinawarp-agentd/test/analytics-redaction.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { sanitizeAnalyticsProperties } from '../dist/analytics.js'
+
+test('sanitizeAnalyticsProperties redacts billing/auth secrets before telemetry', () => {
+  const circular = {}
+  circular.self = circular
+
+  const sanitized = sanitizeAnalyticsProperties({
+    tier: 'pro',
+    customer_id: 'cus_live_123456789',
+    customerId: 'cus_live_987654321',
+    license_key: 'RW-LIVE-LICENSE-KEY',
+    apiKey: 'sk_live_secret',
+    nested: {
+      refresh_token: 'refresh-token-value',
+      stripe_customer_id: 'cus_nested_424242',
+    },
+    entries: [{ token: 'child-token' }],
+    circular,
+  })
+
+  assert.equal(sanitized.tier, 'pro')
+  assert.equal(sanitized.customer_id, '[redacted:6789]')
+  assert.equal(sanitized.customerId, '[redacted:4321]')
+  assert.equal(sanitized.license_key, '[redacted]')
+  assert.equal(sanitized.apiKey, '[redacted]')
+  assert.equal(sanitized.nested.refresh_token, '[redacted]')
+  assert.equal(sanitized.nested.stripe_customer_id, '[redacted:4242]')
+  assert.equal(sanitized.entries[0].token, '[redacted]')
+  assert.equal(sanitized.circular.self, '[redacted]')
+})


### PR DESCRIPTION
## Summary
- Add a central analytics property sanitizer before PostHog/local metrics capture.
- Redact auth/billing-sensitive keys including tokens, secrets, API keys, license keys, and Stripe customer IDs.
- Type the `api_license_generated` event so the public license generation path also flows through the sanitizer without an `any` cast.

Refs #9.

## Validation
- `PATH=/Users/sravansridhar/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm install --frozen-lockfile`
- `PATH=/Users/sravansridhar/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --test packages/rinawarp-agentd/test/analytics-redaction.test.mjs`
- `git diff --check`

## Known repo baseline blocker
- `PATH=/Users/sravansridhar/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --filter @rinawarp/rinawarp-agentd build` currently exits nonzero on existing unresolved workspace/type dependencies such as `@rinawarp/tools/terminal`, `better-sqlite3`, `openai`, `express`, `ws`, and related implicit-any diagnostics. No errors were reported for the changed analytics code before the baseline failures.
